### PR TITLE
docs: fix SIMPLE eval README agent export for MP tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ export agent=psi0_decoupled_wbc
 and set entrypoint and agent to `eval.py` and `psi0` if the evaluating task ends with `MP`, which means the task data is generated using CuRobo Motion planning:
 ```
 export entry=eval.py
-export entry=psi0
+export agent=psi0
 ```
 
 ```


### PR DESCRIPTION
## Summary
- Fixes a README typo in the SIMPLE evaluation instructions.
- Replaces `export entry=psi0` with `export agent=psi0` for tasks ending with `MP`.

## Rationale
- The evaluation command uses `$agent`, so the previous line was inconsistent and misleading.

## Scope
- Documentation only.

## Testing
- Verified the corrected instructions are internally consistent with the command snippet below.
