### PR TITLE
Align validation step with checkpoint step

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -258,7 +258,7 @@ def train(config: LaunchConfig):
 
                 # validation
                 if config.train.validation_steps > 0 and (
-                        global_step % config.train.validation_steps == 0 or 
+                        (global_step + 1) % config.train.validation_steps == 0 or 
                         global_step == trainer.max_training_steps - 1
                     ) :
                     gc.collect()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -258,7 +258,8 @@ def train(config: LaunchConfig):
 
                 # validation
                 if config.train.validation_steps > 0 and (
-                        (global_step + 1) % config.train.validation_steps == 0 or 
+                        global_step == 0 or
+                        (global_step + 1) % config.train.validation_steps == 0 or
                         global_step == trainer.max_training_steps - 1
                     ) :
                     gc.collect()


### PR DESCRIPTION
Validation was triggered on `global_step % validation_steps == 0`, while checkpointing
uses `(global_step + 1) % checkpointing_steps == 0`. This one-step offset means the
eval loss logged near a checkpoint does not correspond to that checkpoint's weights.

As a side effect, validation no longer runs at step 0 (on the barely-trained model right
after the first step)