### PR TITLE
Fix CUDA device mismatch in RTC inference timestep

### DIFF
--- a/src/psi/models/psi0.py
+++ b/src/psi/models/psi0.py
@@ -1836,7 +1836,7 @@ class Psi0Model(nn.Module):
             for i, timestep in enumerate(self.noise_scheduler.timesteps):
                 # batched_timestep = timestep.expand(bsz).to(self.device).detach()
 
-                batched_timestep_masked = torch.where(prefix_mask, 0, timestep).to(self.device) # shape (B, H)
+                batched_timestep_masked = torch.where(prefix_mask, 0, timestep.to(self.device)) # shape (B, H)
 
                 # replace action_samples with clean prev_actions when prefix_mask == True
                 action_samples = torch.where(prefix_mask[:, :, None], prev_actions, action_samples)


### PR DESCRIPTION
In predict_action_with_training_rtc_flow, torch.where(prefix_mask, 0, timestep) mixed a CUDA condition (prefix_mask) with a CPU scalar (the scheduler's timestep), triggering an illegal memory access on the second (RTC-conditioned) act call. The trailing .to(self.device) ran too late. Move timestep to the device inside the where. Safe no-op when timestep is already on-device; the non-RTC path was unaffected.