### PR TITLE
Resolve repo root from __file__ instead of a hard-coded path in psi0_inference_real_sonic

### DIFF
--- a/src/psi/deploy/psi0_inference_real_sonic.py
+++ b/src/psi/deploy/psi0_inference_real_sonic.py
@@ -1,14 +1,18 @@
 import os
-# Set working directory to project root (parent of examples/)
-os.chdir('/hfm/songlin/psi0')
-os.environ['PWD'] = '/hfm/songlin/psi0'
+from pathlib import Path
+
+# Set working directory to project root, so that load_dotenv() below finds the
+# repo .env and the relative run_dir resolves.
+# repo_root/src/psi/deploy/psi0_inference_real_sonic.py -> repo_root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+os.chdir(REPO_ROOT)
+os.environ['PWD'] = str(REPO_ROOT)
 
 import dotenv
 dotenv.load_dotenv()
 
 import torch
 import numpy as np
-from pathlib import Path
 from psi.utils import parse_args_to_tyro_config  #, seed_everything, move_to_device, batchify
 from psi.config.config import LaunchConfig
 


### PR DESCRIPTION
## Problem

`src/psi/deploy/psi0_inference_real_sonic.py` runs this at import time, before anything else:

```python
os.chdir('/hfm/songlin/psi0')
os.environ['PWD'] = '/hfm/songlin/psi0'
```

That path exists on one developer's machine. Anywhere else, importing or running the module raises `FileNotFoundError: [Errno 2] No such file or directory: '/hfm/songlin/psi0'` before any other line executes.

## Change

Compute the repo root from `__file__`, which is the idiom already used by the four sibling scripts in this same directory:

- `src/psi/deploy/download_ckpt.py:14`
- `src/psi/deploy/download_ckpt_ms.py:15`
- `src/psi/deploy/upload_ckpt_hf.py:15`
- `src/psi/deploy/upload_ckpt_ms.py:15`

The original intent is preserved: cwd still becomes the repo root, so `load_dotenv()` finds the repo `.env` and the relative `run_dir` further down still resolves.

`PSI_HOME` would not work as a substitute here — `.env.sample` sets it to a data/cache root (`/hfm`), not to the checkout, which sat one level below it.

The now-redundant `from pathlib import Path` further down the file is dropped.

## Verification

- **Before:** `FileNotFoundError: [Errno 2] No such file or directory: '/hfm/songlin/psi0'` at import.
- **After:** cwd resolves to the repo root and execution proceeds normally to `AssertionError: Path does not exist: .runs/sonic/sonic.lantent64.nortc.real.flow1000.cosine.lr1.0e-04.b128.gpus4.2604120038/argv.txt` — the expected failure for a script pinned to one specific training run that is not present locally.

The portability failure is gone; what remains is purely data-dependent.
